### PR TITLE
Adds delay for 1st keypress

### DIFF
--- a/steno_keyboard.ino
+++ b/steno_keyboard.ino
@@ -26,6 +26,7 @@ void setup() {
 void loop() {
 // accumulate keys  
   do { scan(); } while (!pressed);
+  delay(10); // Debounces 1st keypress
 // until all keys released  
   do { scan(); } while (pressed);
 // debounce the release  


### PR DESCRIPTION
I built my own steno machine and was having some issues with the first key being repeated twice. Adding a delay between the two do-while loops seemed to fix the issue for me.